### PR TITLE
Use mascarade as default network bind mode

### DIFF
--- a/cmd/create_vm.go
+++ b/cmd/create_vm.go
@@ -231,6 +231,22 @@ sudo loginctl enable-linger root
 	requests := map[k8scorev1.ResourceName]resource.Quantity{
 		k8scorev1.ResourceMemory: resource.MustParse("1G"),
 	}
+	networks := []kubevirtcorev1.Network{
+		{
+			Name: "default",
+			NetworkSource: kubevirtcorev1.NetworkSource{
+				Pod: &kubevirtcorev1.PodNetwork{},
+			},
+		},
+	}
+	interfaces := []kubevirtcorev1.Interface{
+		{
+			Name: "default",
+			InterfaceBindingMethod: kubevirtcorev1.InterfaceBindingMethod{
+				Masquerade: &kubevirtcorev1.InterfaceMasquerade{},
+			},
+		},
+	}
 	// Create VMI
 	vmi := &kubevirtcorev1.VirtualMachineInstance{
 		ObjectMeta: k8smetav1.ObjectMeta{
@@ -247,12 +263,14 @@ sudo loginctl enable-linger root
 							Virtiofs: &kubevirtcorev1.FilesystemVirtiofs{},
 						},
 					},
+					Interfaces: interfaces,
 				},
 				Resources: kubevirtcorev1.ResourceRequirements{
 					Requests: requests,
 				},
 			},
 			Volumes: volumes,
+			Networks: networks,
 		},
 	}
 	if SSHKeyPath != "" {


### PR DESCRIPTION
Set mascarade and use the pod interface as default. In certain environment bridge cannot be used, for example on a kind cluster.

Signed-off-by: Alice Frosi <afrosi@redhat.com>